### PR TITLE
fix Adal5HttpService's responseType http option

### DIFF
--- a/dist/adal5-http.service.d.ts
+++ b/dist/adal5-http.service.d.ts
@@ -45,7 +45,7 @@ export declare class Adal5HTTPService {
         params?: HttpParams | {
             [param: string]: string | string[];
         };
-        responseType?: 'json';
+        responseType?: 'json' | 'text' | 'arraybuffer' | 'blob';
         withCredentials?: boolean;
     }): Observable<any>;
     /**
@@ -66,7 +66,7 @@ export declare class Adal5HTTPService {
         params?: HttpParams | {
             [param: string]: string | string[];
         };
-        responseType?: 'json';
+        responseType?: 'json' | 'text' | 'arraybuffer' | 'blob';
         withCredentials?: boolean;
     }): Observable<any>;
     /**
@@ -86,7 +86,7 @@ export declare class Adal5HTTPService {
         params?: HttpParams | {
             [param: string]: string | string[];
         };
-        responseType?: 'json';
+        responseType?: 'json' | 'text' | 'arraybuffer' | 'blob';
         withCredentials?: boolean;
     }): Observable<any>;
     /**
@@ -107,7 +107,7 @@ export declare class Adal5HTTPService {
         params?: HttpParams | {
             [param: string]: string | string[];
         };
-        responseType?: 'json';
+        responseType?: 'json' | 'text' | 'arraybuffer' | 'blob';
         withCredentials?: boolean;
     }): Observable<any>;
     /**
@@ -128,7 +128,7 @@ export declare class Adal5HTTPService {
         params?: HttpParams | {
             [param: string]: string | string[];
         };
-        responseType?: 'json';
+        responseType?: 'json' | 'text' | 'arraybuffer' | 'blob';
         withCredentials?: boolean;
     }): Observable<any>;
     /**
@@ -148,7 +148,7 @@ export declare class Adal5HTTPService {
         params?: HttpParams | {
             [param: string]: string | string[];
         };
-        responseType?: 'json';
+        responseType?: 'json' | 'text' | 'arraybuffer' | 'blob';
         withCredentials?: boolean;
     }): Observable<any>;
     /**

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "adal-angular5",
-  "version": "1.0.36",
-  "description": "ADAL wrapper for Angular5.",
+  "name": "adal-angular5-fork",
+  "version": "1.0.37",
+  "description": "ADAL wrapper for Angular5. (fork by scientificnet.org)",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adal-angular5-fork",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "ADAL wrapper for Angular5. (fork by scientificnet.org)",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "adal-angular5-fork",
-    "version": "1.0.37",
+    "version": "1.0.38",
     "description": "ADAL wrapper for Angular5. (fork by scientificnet.org)",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "adal-angular5",
-    "version": "1.0.36",
-    "description": "ADAL wrapper for Angular5.",
+    "name": "adal-angular5-fork",
+    "version": "1.0.37",
+    "description": "ADAL wrapper for Angular5. (fork by scientificnet.org)",
     "main": "index.js",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/adal5-http.service.ts
+++ b/src/adal5-http.service.ts
@@ -52,7 +52,7 @@ export class Adal5HTTPService {
     reportProgress?: boolean;
     observe: 'response';
     params?: HttpParams | { [param: string]: string | string[]; };
-    responseType?: 'json';
+    responseType?: 'json' | 'text' | 'arraybuffer' | 'blob';
     withCredentials?: boolean;
   }): Observable<any> {
     return this.sendRequest('get', url, options);
@@ -74,7 +74,7 @@ export class Adal5HTTPService {
     reportProgress?: boolean;
     observe: 'response';
     params?: HttpParams | { [param: string]: string | string[]; };
-    responseType?: 'json';
+    responseType?: 'json' | 'text' | 'arraybuffer' | 'blob';
     withCredentials?: boolean;
   }): Observable<any> {
     options.body = body;
@@ -96,7 +96,7 @@ export class Adal5HTTPService {
     reportProgress?: boolean;
     observe: 'response';
     params?: HttpParams | { [param: string]: string | string[]; };
-    responseType?: 'json';
+    responseType?: 'json' | 'text' | 'arraybuffer' | 'blob';
     withCredentials?: boolean;
   }): Observable<any> {
     return this.sendRequest('delete', url, options);
@@ -118,7 +118,7 @@ export class Adal5HTTPService {
     reportProgress?: boolean;
     observe: 'response';
     params?: HttpParams | { [param: string]: string | string[]; };
-    responseType?: 'json';
+    responseType?: 'json' | 'text' | 'arraybuffer' | 'blob';
     withCredentials?: boolean;
   }): Observable<any> {
     options.body = body;
@@ -141,7 +141,7 @@ export class Adal5HTTPService {
     reportProgress?: boolean;
     observe: 'response';
     params?: HttpParams | { [param: string]: string | string[]; };
-    responseType?: 'json';
+    responseType?: 'json' | 'text' | 'arraybuffer' | 'blob';
     withCredentials?: boolean;
   }): Observable<any> {
     options.body = body;
@@ -163,7 +163,7 @@ export class Adal5HTTPService {
     reportProgress?: boolean;
     observe: 'response';
     params?: HttpParams | { [param: string]: string | string[]; };
-    responseType?: 'json';
+    responseType?: 'json' | 'text' | 'arraybuffer' | 'blob';
     withCredentials?: boolean;
   }): Observable<any> {
     return this.sendRequest('head', url, options);
@@ -186,7 +186,7 @@ export class Adal5HTTPService {
     reportProgress?: boolean;
     observe: 'response';
     params?: HttpParams | { [param: string]: string | string[]; };
-    responseType?: 'json';
+    responseType?: 'json' | 'text' | 'arraybuffer' | 'blob';
     withCredentials?: boolean;
   }): Observable<string> {
 


### PR DESCRIPTION
These changes allow to use *Adal5HttpService* to send requests for all content types that angular's HttpClient does:

* json
* text
* blob
* arraybuffer
